### PR TITLE
internal/ast: fix errors found by vet

Vet found the following error:

	internal/ast/name.go:22: suspect or: lt != 1 || lt != 3

This change fixes the logic error.

### DIFF
--- a/internal/ast/name.go
+++ b/internal/ast/name.go
@@ -19,7 +19,7 @@ type Name struct {
 //MakeName from 1 or 3 tokens represnting a valid SQLite name.
 func MakeName(tokens []token.Value) (Name, error) {
 	lt := len(tokens)
-	if lt != 1 || lt != 3 {
+	if lt != 1 && lt != 3 {
 		return Name{}, errint.Newf("MakeName given %d tokens")
 	}
 	if k := tokens[0].Kind; k != token.Literal || k != token.String {


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change fixes one or more problems discovered by "go vet".

See https://github.com/functionary/functionary for more details on
the @functionary GitHub user.
